### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-libignition--sensors5-green.svg)](https://anaconda.org/conda-forge/libignition-sensors5) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libignition-sensors5.svg)](https://anaconda.org/conda-forge/libignition-sensors5) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libignition-sensors5.svg)](https://anaconda.org/conda-forge/libignition-sensors5) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libignition-sensors5.svg)](https://anaconda.org/conda-forge/libignition-sensors5) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libignition--sensors6-green.svg)](https://anaconda.org/conda-forge/libignition-sensors6) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libignition-sensors6.svg)](https://anaconda.org/conda-forge/libignition-sensors6) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libignition-sensors6.svg)](https://anaconda.org/conda-forge/libignition-sensors6) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libignition-sensors6.svg)](https://anaconda.org/conda-forge/libignition-sensors6) |
 
 Installing libignition-sensors
 ==============================
@@ -93,16 +93,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libignition-sensors5` can be installed with:
+Once the `conda-forge` channel has been enabled, `libignition-sensors6` can be installed with:
 
 ```
-conda install libignition-sensors5
+conda install libignition-sensors6
 ```
 
-It is possible to list all of the versions of `libignition-sensors5` available on your platform with:
+It is possible to list all of the versions of `libignition-sensors6` available on your platform with:
 
 ```
-conda search libignition-sensors5 --channel conda-forge
+conda search libignition-sensors6 --channel conda-forge
 ```
 
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,4 @@ conda_forge_output_validation: true
 bot:
   abi_migration_branches:
     - "v4"
+    - "v5"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,5 +22,5 @@ cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest -C Release
+ctest -VV -C Release
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,5 +22,5 @@ cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest -VV -C Release
+ctest -VV -C Release  -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION"
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ cmake --build . --config Release
 cmake --build . --config Release --target install
 
 if [[ ${HOST} =~ .*darwin.* ]]; then
-    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST"
+    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION"
 else
     ctest -VV --output-on-failure -C Release
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ cmake --build . --config Release
 cmake --build . --config Release --target install
 
 if [[ ${HOST} =~ .*darwin.* ]]; then
-    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION_camera_plugin|INTEGRATION_depth_camera_plugin|INTEGRATION_gpu_lidar_sensor_plugin|INTEGRATION_rgbd_camera_plugin|INTEGRATION_thermal_camera_plugin"
+    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION"
 else
     ctest -VV --output-on-failure -C Release
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ cmake --build . --config Release
 cmake --build . --config Release --target install
 
 if [[ ${HOST} =~ .*darwin.* ]]; then
-    ctest --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION_camera_plugin|INTEGRATION_depth_camera_plugin|INTEGRATION_gpu_lidar_sensor_plugin|INTEGRATION_rgbd_camera_plugin|INTEGRATION_thermal_camera_plugin"
+    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION_camera_plugin|INTEGRATION_depth_camera_plugin|INTEGRATION_gpu_lidar_sensor_plugin|INTEGRATION_rgbd_camera_plugin|INTEGRATION_thermal_camera_plugin"
 else
-    ctest --output-on-failure -C Release
+    ctest -VV --output-on-failure -C Release
 fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ cmake --build . --config Release
 cmake --build . --config Release --target install
 
 if [[ ${HOST} =~ .*darwin.* ]]; then
-    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST|INTEGRATION"
+    ctest -VV --output-on-failure -C Release -E "UNIT_Lidar_TEST|UNIT_Camera_TEST"
 else
     ctest -VV --output-on-failure -C Release
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,11 +30,11 @@ requirements:
     - libprotobuf
     - libignition-math6
     - libignition-common4
-    - libignition-transport10
-    - libignition-rendering5
-    - libignition-msgs7
+    - libignition-transport11
+    - libignition-rendering6
+    - libignition-msgs8
     - libignition-plugin1
-    - libsdformat11
+    - libsdformat12
     - libarchive  # [osx]
     - ogre  {{ ogre }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set component_name = "sensors" %}
 {% set base_name = "libignition-" + component_name %}
-{% set version = "5_5.0.0" %}
+{% set version = "6_6.0.0" %}
 {% set version_package = version.split('_')[1] %}
 {% set major_version = version.split('_')[0] %}
 {% set name = base_name + major_version %}
@@ -11,10 +11,10 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ version }}.tar.gz
-    sha256: 2484b82d2122633956fdf3fab9e8a41fd8c18de3055d059ec461c9b9153c3257
+    sha256: ad9da18d8d1316bccfe86e943c3f66b806cf3614bcf79479fc86c94a0c3680de
 
 build:
-  number: 4
+  number: 0
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
This was done manually due to https://github.com/conda-forge/libignition-gazebo-feedstock/issues/24 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


